### PR TITLE
remove duplicate development gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "rx-file" , git: "https://github.com/ruby-x/rx-file"
 group :test do
 # reporter and parallel dont work together
 #  gem "minitest-reporters"
-  gem "minitest-parallel_fork"
   gem "codeclimate-test-reporter" , require: false
   gem "simplecov"
   gem "minitest-color"


### PR DESCRIPTION
Commit 741e9cc61eb35cea59e24e3eecfa6ef3aaebdd1c was missing this.

Leads to annoying errors such as

```
$ bundle
Your Gemfile lists the gem minitest-parallel_fork (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```